### PR TITLE
Fix money preview with Manual Trigger off

### DIFF
--- a/src/Core.lua
+++ b/src/Core.lua
@@ -248,7 +248,6 @@ function G.FUNCS.dv_pre_dollars_UI_set(e)
    local new_colour = nil
    if DV.PRE.data and G.SETTINGS.DV.preview_dollars
       and not DV.PRE.delay.active and not G.HUD:get_UIE_by_ID("dv_pre_manual_button")
-      and G.SETTINGS.DV.manual_preview
    then
       if G.SETTINGS.DV.show_min_max and (DV.PRE.data.dollars.min ~= DV.PRE.data.dollars.max) then
          if e.config.id == "dv_pre_dollars_top" then


### PR DESCRIPTION
closes https://github.com/DivvyCr/Balatro-Preview/issues/49.

The new behavior, assuming "money preview" is on:

If "manual preview" is on, but the preview button has not yet been clicked:
- displays money +??

If "manual preview" is on, but the preview button has been clicked:
- displays the money preview, which is either a single +X value or a range min-max +X +Y

If "manual preview" is off (same result as above)
- displays the money preview, which is either a single +X value or a range min-max +X +Y